### PR TITLE
Allow empty type when querying therlinks

### DIFF
--- a/src/main/kotlin/org/taktik/connector/business/therlink/domain/TherapeuticLink.kt
+++ b/src/main/kotlin/org/taktik/connector/business/therlink/domain/TherapeuticLink.kt
@@ -12,7 +12,7 @@ import org.taktik.connector.business.common.domain.Patient
 open class TherapeuticLink(
     var patient: Patient = Patient(),
     var hcParty: HcParty = HcParty(),
-    var type: String = "gpconsultation"
+    var type: String? = null
 ) : Serializable {
     var startDate: LocalDate? = null
     var endDate: LocalDate? = null

--- a/src/main/kotlin/org/taktik/connector/business/therlink/mappers/RequestObjectMapper.kt
+++ b/src/main/kotlin/org/taktik/connector/business/therlink/mappers/RequestObjectMapper.kt
@@ -116,11 +116,13 @@ class RequestObjectMapper {
         GetTherapeuticLinkSelectType().apply {
             begindate = it.startDate?.let { it.toDateTime(LocalTime.MIDNIGHT) }
             enddate = it.endDate?.let { it.toDateTime(LocalTime.MIDNIGHT) }
-            cds.add(CDTHERAPEUTICLINK().apply {
-                s = CDTHERAPEUTICLINKschemes.CD_THERAPEUTICLINKTYPE
-                sv = "1.0"
-                value = link.type
-            })
+            if(link.type != null){
+                cds.add(CDTHERAPEUTICLINK().apply {
+                    s = CDTHERAPEUTICLINKschemes.CD_THERAPEUTICLINKTYPE
+                    sv = "1.0"
+                    value = link.type
+                })
+            }
             it.status?.let { therapeuticlinkstatus = it.toString().toLowerCase(Locale.getDefault()) }
             patientsAndHcparties.add(mapPatient(it.patient))
             patientsAndHcparties.add(mapHcPartyIdType(it.hcParty))

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TherLinkServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/TherLinkServiceImpl.kt
@@ -120,16 +120,17 @@ class TherLinkServiceImpl(private val stsService: STSService) : TherLinkService 
             stsService.getSAMLToken(tokenId, keystoreId, passPhrase)
                 ?: throw IllegalArgumentException("Cannot obtain token for Ehealth Box operations")
 
-        val response =
+        val query = GetTherapeuticLinkRequest(DateTime.now(),getNihii(queryLink.hcParty)!!, Author().apply { hcParties.add(queryLink.hcParty) }, queryLink, 100, proof)
+
+
+        val rawResponse =
             org.taktik.connector.technical.ws.ServiceFactory.getGenericWsSender()
                 .send(getTherLinkPort(samlToken).apply {
                     setSoapAction("urn:be:fgov:ehealth:therlink:protocol:v1:GetTherapeuticLink")
-                    setPayload(
-                        requestObjectMapper.mapGetTherapeuticLinkRequest(
-                            GetTherapeuticLinkRequest(DateTime.now(),getNihii(queryLink.hcParty)!!, Author().apply { hcParties.add(queryLink.hcParty) }, queryLink, 100, proof)
-                                                                        )
-                              )
-                }).asObject(GetTherapeuticLinkResponse::class.java)
+                    setPayload(requestObjectMapper.mapGetTherapeuticLinkRequest(query))
+                })
+
+        val response = rawResponse.asObject(GetTherapeuticLinkResponse::class.java)
 
         return if (response.acknowledge.isIscomplete) {
             responseObjectMapper.mapJaxbToGetTherapeuticLinkResponse(response)
@@ -306,7 +307,7 @@ class TherLinkServiceImpl(private val stsService: STSService) : TherLinkService 
                     therLink.hcParty.familyName
                           ),
                 makeTherapeuticLink(
-                    therLink.type,
+                    therLink.type!!,
                     therLink.hcParty,
                     therLink.patient,
                     therLink.startDate?.toDateTime(LocalTime.MIDNIGHT) ?: DateTime(),


### PR DESCRIPTION
When querying therlinks in Medispring with no type, the FHC assumes that we want the `gpconsultation` type as default, but the default should be empty, querying for all types of links. 