### PR TITLE
MS-543 - Add owner in SamlTokenResult

### DIFF
--- a/src/main/java/org/taktik/connector/technical/utils/CertificateParser.java
+++ b/src/main/java/org/taktik/connector/technical/utils/CertificateParser.java
@@ -28,6 +28,7 @@ public class CertificateParser {
    private String type;
    private String id;
    private String application;
+   private String owner;
 
    public CertificateParser(X509Certificate cert) throws TechnicalConnectorException {
       this(cert.getSubjectX500Principal().getName("RFC2253"));
@@ -37,6 +38,7 @@ public class CertificateParser {
       this.type = "";
       this.id = "";
       this.application = "";
+      this.owner = "";
       LdapName name = null;
 
       try {
@@ -88,6 +90,8 @@ public class CertificateParser {
                      if (cn.endsWith(ou)) {
                         LOG.debug("ApplicationId is present.");
                         this.application = ou;
+                     } else {
+                        this.owner = ou;
                      }
                   }
                }
@@ -136,6 +140,10 @@ public class CertificateParser {
 
    public final String getApplication() {
       return this.application;
+   }
+
+   public final String getOwner() {
+      return this.owner;
    }
 
    public final IdentifierType getIdentifier() {

--- a/src/main/kotlin/org/taktik/freehealth/middleware/domain/sts/SamlTokenResult.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/domain/sts/SamlTokenResult.kt
@@ -23,4 +23,4 @@ package org.taktik.freehealth.middleware.domain.sts
 import java.io.Serializable
 import java.util.*
 
-class SamlTokenResult(var tokenId: UUID? = null, var token: String? = null, var validity: Long? = null) : Serializable
+class SamlTokenResult(var tokenId: UUID? = null, var token: String? = null, var validity: Long? = null, var owner: String? = null) : Serializable

--- a/src/main/kotlin/org/taktik/freehealth/middleware/domain/sts/SamlTokenResult.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/domain/sts/SamlTokenResult.kt
@@ -23,4 +23,4 @@ package org.taktik.freehealth.middleware.domain.sts
 import java.io.Serializable
 import java.util.*
 
-class SamlTokenResult(var tokenId: UUID? = null, var token: String? = null, var validity: Long? = null, var owner: String? = null) : Serializable
+class SamlTokenResult(var tokenId: UUID? = null, var token: String? = null, var validity: Long? = null, var type: String? = null, var id: String? = null, var application: String? = null, var owner: String? = null) : Serializable

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
@@ -209,9 +209,8 @@ class STSServiceImpl(val keystoresMap: IMap<UUID, ByteArray>, val tokensMap: IMa
             val randomUUID = UUID.randomUUID()
             val samlToken = result.writer.toString()
 
-
             val samlTokenResult =
-                SamlTokenResult(randomUUID, samlToken, SAMLHelper.getNotOnOrAfterCondition(assertion).toInstant().millis)
+                SamlTokenResult(randomUUID, samlToken, SAMLHelper.getNotOnOrAfterCondition(assertion).toInstant().millis, CertificateParser(credential.certificate).owner)
             tokensMap[randomUUID] = samlTokenResult
             log.info("tokensMap size: ${tokensMap.size}")
 

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/STSServiceImpl.kt
@@ -208,9 +208,10 @@ class STSServiceImpl(val keystoresMap: IMap<UUID, ByteArray>, val tokensMap: IMa
             transformer.transform(DOMSource(assertion), result)
             val randomUUID = UUID.randomUUID()
             val samlToken = result.writer.toString()
+            val parser = CertificateParser(credential.certificate)
 
             val samlTokenResult =
-                SamlTokenResult(randomUUID, samlToken, SAMLHelper.getNotOnOrAfterCondition(assertion).toInstant().millis, CertificateParser(credential.certificate).owner)
+                SamlTokenResult(randomUUID, samlToken, SAMLHelper.getNotOnOrAfterCondition(assertion).toInstant().millis, parser.type, parser.id, parser.application, parser.owner)
             tokensMap[randomUUID] = samlTokenResult
             log.info("tokensMap size: ${tokensMap.size}")
 


### PR DESCRIPTION
/!\ The code actually parses two times the certificate.
We should not call `CertificateParser(credential.certificate).owner` since this involves a re-parsing of the certificate. We need to refactor this to have only one call to the parser.